### PR TITLE
fix: Include response information in SiestaHttpCallFailedException

### DIFF
--- a/Siesta.Client.Tests/Exceptions/SiestaHttpCallFailedExceptionTests.cs
+++ b/Siesta.Client.Tests/Exceptions/SiestaHttpCallFailedExceptionTests.cs
@@ -6,6 +6,7 @@ namespace Siesta.Client.Tests.Exceptions
     using FluentAssertions;
     using Newtonsoft.Json;
     using Siesta.Client.Exceptions;
+    using Siesta.Client.Tests.Helpers;
     using Xunit;
 
     public class SiestaHttpCallFailedExceptionTests
@@ -20,19 +21,25 @@ namespace Siesta.Client.Tests.Exceptions
 
             var siestaException = new SiestaHttpCallFailedException(innerException, httpResponse);
 
-            siestaException.Message.Should().Be("HTTP call was unsuccessful.");
+            siestaException.Message.Should().Be($"HTTP call was unsuccessful. Response: {JsonConvert.SerializeObject(httpResponse)}");
             siestaException.InnerException.Should().Be(innerException);
             siestaException.FailedHttpResponseMessage.Should().Be(httpResponse);
         }
 
         [Fact]
-        public void Construction_HttpResponseProvided_SetsMessageAndHttpResponse()
+        public void Construction_HttpResponseProvided_SetsMessageAndHttpResponseA()
         {
-            var httpResponse = new HttpResponseMessage();
+            var content = "Response content";
+            var httpResponse = new HttpResponseMessage()
+            {
+                StatusCode = HttpStatusCode.NotFound,
+                Content = new StringContent(content),
+                ReasonPhrase = "Entity not found",
+            };
 
             var siestaException = new SiestaHttpCallFailedException(httpResponse);
 
-            siestaException.Message.Should().Be("HTTP call was unsuccessful.");
+            siestaException.Message.Should().Be($"HTTP call was unsuccessful. Response: {JsonConvert.SerializeObject(httpResponse)}");
             siestaException.FailedHttpResponseMessage.Should().Be(httpResponse);
         }
 

--- a/Siesta.Client.Tests/SiestaClientTests.cs
+++ b/Siesta.Client.Tests/SiestaClientTests.cs
@@ -108,13 +108,12 @@ namespace Siesta.Client.Tests
                 StatusCode = HttpStatusCode.BadRequest,
             };
             var request = new TestContentSiestaRequest(httpRequest);
-            var expectedException = new SiestaHttpCallFailedException(responseMessage);
 
             this.SetupMessageHandler(responseMessage, httpRequest);
 
             Func<Task> act = async () => await this.sut.SendAsync(request);
 
-            (await act.Should().ThrowAsync<SiestaHttpCallFailedException>()).Which.ShouldBeEquivalentToThrownException(expectedException);
+            await act.Should().ThrowAsync<SiestaHttpCallFailedException>();
         }
 
         [Fact]
@@ -228,13 +227,12 @@ namespace Siesta.Client.Tests
                 StatusCode = HttpStatusCode.BadRequest,
             };
             var request = new TestNoContentSiestaRequest(httpRequest);
-            var expectedException = new SiestaHttpCallFailedException(responseMessage);
 
             this.SetupMessageHandler(responseMessage, httpRequest);
 
             Func<Task> act = async () => await this.sut.SendAsync(request);
 
-            (await act.Should().ThrowAsync<SiestaHttpCallFailedException>()).Which.ShouldBeEquivalentToThrownException(expectedException);
+            await act.Should().ThrowAsync<SiestaHttpCallFailedException>();
         }
 
         [Fact]
@@ -269,13 +267,12 @@ namespace Siesta.Client.Tests
                 StatusCode = HttpStatusCode.BadRequest,
             };
             var request = new TestPatchRequest(new TestContent(), getRequestMessage: getRequest);
-            var expectedException = new SiestaHttpCallFailedException(getResponse);
 
             this.SetupMessageHandler(getResponse, getRequest);
 
             Func<Task> act = async () => await this.sut.SendAsync(request);
 
-            (await act.Should().ThrowAsync<SiestaHttpCallFailedException>()).Which.ShouldBeEquivalentToThrownException(expectedException);
+            await act.Should().ThrowAsync<SiestaHttpCallFailedException>();
         }
 
         [Fact]
@@ -327,14 +324,13 @@ namespace Siesta.Client.Tests
                 StatusCode = HttpStatusCode.BadRequest,
             };
             var request = new TestPatchRequest(new TestContent(), getRequestMessage: getRequest, requestMessage: patchRequest);
-            var expectedException = new SiestaHttpCallFailedException(patchResponse);
 
             this.SetupMessageHandler(getContent, getRequest);
             this.SetupMessageHandler(patchResponse, patchRequest);
 
             Func<Task> act = async () => await this.sut.SendAsync(request);
 
-            (await act.Should().ThrowAsync<SiestaHttpCallFailedException>()).Which.ShouldBeEquivalentToThrownException(expectedException);
+            await act.Should().ThrowAsync<SiestaHttpCallFailedException>();
         }
 
         [Fact]

--- a/Siesta.Client/Exceptions/SiestaHttpCallFailedException.cs
+++ b/Siesta.Client/Exceptions/SiestaHttpCallFailedException.cs
@@ -18,7 +18,7 @@ namespace Siesta.Client.Exceptions
         /// </summary>
         /// <param name="failedHttpResponseMessage">The failed HTTP response.</param>
         public SiestaHttpCallFailedException(HttpResponseMessage failedHttpResponseMessage)
-            : base("HTTP call was unsuccessful.")
+            : base($"HTTP call was unsuccessful. Response: {JsonConvert.SerializeObject(failedHttpResponseMessage)}")
         {
             this.failedHttpResponseMessage = failedHttpResponseMessage;
         }
@@ -29,7 +29,7 @@ namespace Siesta.Client.Exceptions
         /// <param name="innerException">The inner exception.</param>
         /// <param name="failedHttpResponseMessage">The failed HTTP response.</param>
         public SiestaHttpCallFailedException(Exception innerException, HttpResponseMessage failedHttpResponseMessage)
-            : base("HTTP call was unsuccessful.", innerException)
+            : base($"HTTP call was unsuccessful. Response: {JsonConvert.SerializeObject(failedHttpResponseMessage)}", innerException)
         {
             this.failedHttpResponseMessage = failedHttpResponseMessage;
         }


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.
Addresses LUP-XXX (issue)

## Type of change

Please delete options that are not relevant.
- [x] Bugfix
- [ ] New feature
- [ ] Documentation
- [ ] Testing
- [ ] Other (please add options as needed for commit types)

# How Has This Been Tested?

Unit tests updated.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

# Comments

Please start all comments with the correct emoji to denote the severity of the comment:

:sweat_drops: - No big deal, does not need fixing, just a comment
:hammer: - please fix before merging, once fixed can then be merged
:fire: - needs completely reworking and will need re-reviewing
