### PR TITLE
fix: Include response content in SiestaHttpCallFailedException

### DIFF
--- a/Siesta.Client.Tests/Exceptions/SiestaHttpCallFailedExceptionTests.cs
+++ b/Siesta.Client.Tests/Exceptions/SiestaHttpCallFailedExceptionTests.cs
@@ -6,7 +6,6 @@ namespace Siesta.Client.Tests.Exceptions
     using FluentAssertions;
     using Newtonsoft.Json;
     using Siesta.Client.Exceptions;
-    using Siesta.Client.Tests.Helpers;
     using Xunit;
 
     public class SiestaHttpCallFailedExceptionTests
@@ -19,9 +18,12 @@ namespace Siesta.Client.Tests.Exceptions
             var innerException = new Exception();
             var httpResponse = new HttpResponseMessage();
 
+            var expectedMessage = $"HTTP call was unsuccessful. " +
+                $"Response: {JsonConvert.SerializeObject(new { failedHttpResponseMessage = httpResponse, failedMessageContent = string.Empty })}";
+
             var siestaException = new SiestaHttpCallFailedException(innerException, httpResponse);
 
-            siestaException.Message.Should().Be($"HTTP call was unsuccessful. Response: {JsonConvert.SerializeObject(httpResponse)}");
+            siestaException.Message.Should().Be(expectedMessage);
             siestaException.InnerException.Should().Be(innerException);
             siestaException.FailedHttpResponseMessage.Should().Be(httpResponse);
         }
@@ -37,9 +39,12 @@ namespace Siesta.Client.Tests.Exceptions
                 ReasonPhrase = "Entity not found",
             };
 
-            var siestaException = new SiestaHttpCallFailedException(httpResponse);
+            var expectedMessage = $"HTTP call was unsuccessful. " +
+                $"Response: {JsonConvert.SerializeObject(new { failedHttpResponseMessage = httpResponse, failedMessageContent = content })}";
 
-            siestaException.Message.Should().Be($"HTTP call was unsuccessful. Response: {JsonConvert.SerializeObject(httpResponse)}");
+            var siestaException = new SiestaHttpCallFailedException(httpResponse, content);
+
+            siestaException.Message.Should().Be(expectedMessage);
             siestaException.FailedHttpResponseMessage.Should().Be(httpResponse);
         }
 

--- a/Siesta.Client/Exceptions/SiestaHttpCallFailedException.cs
+++ b/Siesta.Client/Exceptions/SiestaHttpCallFailedException.cs
@@ -11,16 +11,19 @@ namespace Siesta.Client.Exceptions
     [Serializable]
     public class SiestaHttpCallFailedException : Exception
     {
-        private HttpResponseMessage failedHttpResponseMessage;
+        private readonly HttpResponseMessage failedHttpResponseMessage;
+        private readonly string? failedMessageContent;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SiestaHttpCallFailedException"/> class.
         /// </summary>
         /// <param name="failedHttpResponseMessage">The failed HTTP response.</param>
-        public SiestaHttpCallFailedException(HttpResponseMessage failedHttpResponseMessage)
-            : base($"HTTP call was unsuccessful. Response: {JsonConvert.SerializeObject(failedHttpResponseMessage)}")
+        /// <param name="failedMessageContent">Content of the failed HTTP response.</param>
+        public SiestaHttpCallFailedException(HttpResponseMessage failedHttpResponseMessage, string failedMessageContent = "")
+            : base($"HTTP call was unsuccessful. Response: {JsonConvert.SerializeObject(new { failedHttpResponseMessage, failedMessageContent })}")
         {
             this.failedHttpResponseMessage = failedHttpResponseMessage;
+            this.failedMessageContent = failedMessageContent;
         }
 
         /// <summary>
@@ -28,10 +31,14 @@ namespace Siesta.Client.Exceptions
         /// </summary>
         /// <param name="innerException">The inner exception.</param>
         /// <param name="failedHttpResponseMessage">The failed HTTP response.</param>
-        public SiestaHttpCallFailedException(Exception innerException, HttpResponseMessage failedHttpResponseMessage)
-            : base($"HTTP call was unsuccessful. Response: {JsonConvert.SerializeObject(failedHttpResponseMessage)}", innerException)
+        /// <param name="failedMessageContent">Content of the failed HTTP response.</param>
+        public SiestaHttpCallFailedException(Exception innerException, HttpResponseMessage failedHttpResponseMessage, string failedMessageContent = "")
+            : base(
+                  $"HTTP call was unsuccessful. Response: {JsonConvert.SerializeObject(new { failedHttpResponseMessage, failedMessageContent })}",
+                  innerException)
         {
             this.failedHttpResponseMessage = failedHttpResponseMessage;
+            this.failedMessageContent = failedMessageContent;
         }
 
         /// <summary>
@@ -45,6 +52,8 @@ namespace Siesta.Client.Exceptions
         {
             this.failedHttpResponseMessage =
                 (HttpResponseMessage)info.GetValue("failedHttpResponseMessage", typeof(HttpResponseMessage)) !;
+
+            this.failedMessageContent = info.GetString("failedMessageContent");
         }
 
         /// <summary>
@@ -61,6 +70,8 @@ namespace Siesta.Client.Exceptions
             }
 
             info.AddValue("failedHttpResponseMessage", this.failedHttpResponseMessage);
+            info.AddValue("failedMessageContent", this.failedMessageContent);
+
             base.GetObjectData(info, context);
         }
     }

--- a/Siesta.Client/SiestaClient.cs
+++ b/Siesta.Client/SiestaClient.cs
@@ -95,13 +95,12 @@ namespace Siesta.Client
             }
 
             var response = await this.client.SendAsync(requestMessage);
+            var content = await response.Content.ReadAsStringAsync();
 
             if (!response.IsSuccessStatusCode)
             {
-                throw new SiestaHttpCallFailedException(response);
+                throw new SiestaHttpCallFailedException(response, content);
             }
-
-            var content = await response.Content.ReadAsStringAsync();
 
             if (!string.IsNullOrEmpty(content))
             {
@@ -119,15 +118,16 @@ namespace Siesta.Client
             }
 
             var response = await this.client.SendAsync(requestMessage);
+            var content = await response.Content.ReadAsStringAsync();
 
             if (!response.IsSuccessStatusCode)
             {
-                throw new SiestaHttpCallFailedException(response);
+                throw new SiestaHttpCallFailedException(response, content);
             }
 
             try
             {
-                var deserialized = JsonConvert.DeserializeObject<T>(await response.Content.ReadAsStringAsync());
+                var deserialized = JsonConvert.DeserializeObject<T>(content);
 
                 if (deserialized == null)
                 {


### PR DESCRIPTION
# Description

In addition to the failed response, add the responses' content which by default does not get serialised.

## Type of change

Please delete options that are not relevant.
- [x] Bugfix
- [ ] New feature
- [ ] Documentation
- [ ] Testing
- [ ] Other (please add options as needed for commit types)

# How Has This Been Tested?

Locally created new nuget package version and test the newer version with TAS to see the content of a failed message being presented with the exception.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

# Comments

Please start all comments with the correct emoji to denote the severity of the comment:

:sweat_drops: - No big deal, does not need fixing, just a comment
:hammer: - please fix before merging, once fixed can then be merged
:fire: - needs completely reworking and will need re-reviewing
