### PR TITLE
fix: SerializablePagedList meta data not preserved

### DIFF
--- a/Siesta.Configuration.Tests/Serialization/SerializablePagedListTests.cs
+++ b/Siesta.Configuration.Tests/Serialization/SerializablePagedListTests.cs
@@ -14,18 +14,7 @@
         {
             IEnumerable<string> sequence = new string[] { "abc", "def", "efg", "ghi", "jkl" };
 
-            var paged = new SerializablePagedList<string>(sequence, 1, 5);
-
-            JsonConvert.DeserializeObject<DeserializedPagedList<string>>(JsonConvert.SerializeObject(paged))
-                .Should().Equal(paged);
-        }
-
-        [Fact]
-        public void SerializablePagedList_WithIQueryableInput_IsSerializedAndDeserializedProperly()
-        {
-            var sequence = new string[] { "abc", "def", "efg", "ghi", "jkl" }.AsQueryable();
-
-            var paged = new SerializablePagedList<string>(sequence, 1, 5);
+            var paged = new SerializablePagedList<string>(sequence, 1, 5, sequence.Count());
 
             JsonConvert.DeserializeObject<DeserializedPagedList<string>>(JsonConvert.SerializeObject(paged))
                 .Should().Equal(paged);
@@ -36,8 +25,8 @@
         {
             IEnumerable<string> sequence = new string[] { "abc", "def", "efg", "ghi", "jkl" };
 
-            var pagedToSecond = new SerializablePagedList<string>(sequence, 2, 2);
-            var pagedToThird = new SerializablePagedList<string>(sequence, 3, 2);
+            var pagedToSecond = new SerializablePagedList<string>(sequence, 2, 2, sequence.Count());
+            var pagedToThird = new SerializablePagedList<string>(sequence, 3, 2, sequence.Count());
 
             JsonConvert.DeserializeObject<DeserializedPagedList<string>>(JsonConvert.SerializeObject(pagedToSecond))
                 .Should().Equal(pagedToSecond);
@@ -50,7 +39,7 @@
         {
             IEnumerable<string> sequence = new string[] { "abc", "def", "efg", "ghi", "jkl" };
 
-            var paged = new SerializablePagedList<string>(sequence, 2, 5);
+            var paged = new SerializablePagedList<string>(sequence, 2, 5, sequence.Count());
 
             JsonConvert.DeserializeObject<DeserializedPagedList<string>>(JsonConvert.SerializeObject(paged))
                 .Should().Equal(paged);

--- a/Siesta.Configuration/Serialization/SerializablePagedList.cs
+++ b/Siesta.Configuration/Serialization/SerializablePagedList.cs
@@ -11,27 +11,17 @@
     /// </summary>
     /// <typeparam name="T">Type of the entity stored in set.</typeparam>
     [JsonObject]
-    public class SerializablePagedList<T> : PagedList<T>
+    public class SerializablePagedList<T> : StaticPagedList<T>
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="SerializablePagedList{T}"/> class.
-        /// </summary>
-        /// <param name="items">IQueryable set of entities.</param>
-        /// <param name="pageNumber">Number of page on which data will be displayed.</param>
-        /// <param name="pageSize">Maximum size of the set.</param>
-        public SerializablePagedList(IQueryable<T> items, int pageNumber, int pageSize)
-        : base(items, pageNumber, pageSize)
-        {
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="SerializablePagedList{T}"/> class.
         /// </summary>
         /// <param name="items">IEnumerable set of entities.</param>
         /// <param name="pageNumber">Number of page on which data will be displayed.</param>
         /// <param name="pageSize">Maximum size of the set.</param>
-        public SerializablePagedList(IEnumerable<T> items, int pageNumber, int pageSize)
-            : base(items, pageNumber, pageSize)
+        /// <param name="totalItemCount">Total item count.</param>
+        public SerializablePagedList(IEnumerable<T> items, int pageNumber, int pageSize, int totalItemCount)
+            : base(items, pageNumber, pageSize, totalItemCount)
         {
         }
 


### PR DESCRIPTION
# Description

Changed the Serializable Paged list to a static paged list which makes it easier to create the list, or transform from a different list.

## Type of change

Please delete options that are not relevant.
- [x] Bugfix
- [ ] New feature
- [ ] Documentation
- [ ] Testing
- [ ] Other (please add options as needed for commit types)

# How Has This Been Tested?

Tested in TAS

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

# Comments

Please start all comments with the correct emoji to denote the severity of the comment:

:sweat_drops: - No big deal, does not need fixing, just a comment
:hammer: - please fix before merging, once fixed can then be merged
:fire: - needs completely reworking and will need re-reviewing
