### PR TITLE
fix: Allow no required content requests

### DIFF
--- a/Siesta.Client.Tests/Siesta.Client.Tests.csproj
+++ b/Siesta.Client.Tests/Siesta.Client.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <IsPackable>false</IsPackable>
         <Nullable>enable</Nullable>
         <CodeAnalysisRuleSet>..\Siesta.Tests.ruleset</CodeAnalysisRuleSet>

--- a/Siesta.Client.Tests/SiestaClientTests.cs
+++ b/Siesta.Client.Tests/SiestaClientTests.cs
@@ -236,7 +236,7 @@ namespace Siesta.Client.Tests
         }
 
         [Fact]
-        public async Task SendAsyncNoContent_ExpectedHttpContentNotNull_ThrowsSiestaContentException()
+        public async Task SendAsyncNoContent_ExpectedHttpContentNotNull_ReturnsCompletedTask()
         {
             var httpRequest = new HttpRequestMessage();
             var responseMessage = new HttpResponseMessage
@@ -245,13 +245,12 @@ namespace Siesta.Client.Tests
                 Content = new StringContent("just a string"),
             };
             var request = new TestNoContentSiestaRequest(httpRequest);
-            var expectedException = new SiestaContentException(responseMessage);
 
             this.SetupMessageHandler(responseMessage, httpRequest);
 
-            Func<Task> act = async () => await this.sut.SendAsync(request);
+            var result = await this.sut.SendAsync(request);
 
-            (await act.Should().ThrowAsync<SiestaContentException>()).Which.ShouldBeEquivalentToThrownException(expectedException);
+            result.IsCompleted.Should().BeTrue();
         }
 
         #endregion

--- a/Siesta.Client/ISiestaClient.cs
+++ b/Siesta.Client/ISiestaClient.cs
@@ -11,7 +11,7 @@ namespace Siesta.Client
     public interface ISiestaClient
     {
         /// <summary>
-        /// Sends a request that expects no data in return.
+        /// Sends a request that requires no data in return.
         /// </summary>
         /// <param name="siestaRequest">The request to send.</param>
         /// <returns>A completed task.</returns>
@@ -19,7 +19,7 @@ namespace Siesta.Client
         Task<Task> SendAsync(SiestaRequest siestaRequest);
 
         /// <summary>
-        /// Sends a request that expects no data in return.
+        /// Sends a request that requires no data in return.
         /// </summary>
         /// <param name="siestaRequest">The request to send.</param>
         /// <param name="currentCorrelationId">If you are using a correlation ID and you are already part of a call you can pass this here.</param>
@@ -28,7 +28,7 @@ namespace Siesta.Client
         Task<Task> SendAsync(SiestaRequest siestaRequest, string? currentCorrelationId);
 
         /// <summary>
-        /// Sends a request that expects data in return.
+        /// Sends a request that requires data in return.
         /// </summary>
         /// <param name="siestaRequest">The request to send.</param>
         /// <typeparam name="TResource">The type of the resource.</typeparam>
@@ -38,7 +38,7 @@ namespace Siesta.Client
         Task<TReturn> SendAsync<TResource, TReturn>(SiestaRequest<TResource, TReturn> siestaRequest);
 
         /// <summary>
-        /// Sends a request that expects data in return.
+        /// Sends a request that requires data in return.
         /// </summary>
         /// <param name="siestaRequest">The request to send.</param>
         /// <param name="currentCorrelationId">If you are using a correlation ID and you are already part of a call you can pass this here.</param>
@@ -49,7 +49,7 @@ namespace Siesta.Client
         Task<TReturn> SendAsync<TResource, TReturn>(SiestaRequest<TResource, TReturn> siestaRequest, string? currentCorrelationId);
 
         /// <summary>
-        /// Sends a PATCH request that expected data in return.
+        /// Sends a PATCH request that requires data in return.
         /// </summary>
         /// <param name="siestaPatchRequest">The request to send.</param>
         /// <typeparam name="TReturn">The type of the object returned from the PATCH request.</typeparam>
@@ -60,7 +60,7 @@ namespace Siesta.Client
         Task<TReturn> SendAsync<TReturn, TResource, TGetReturn>(SiestaPatchRequest<TReturn, TResource, TGetReturn> siestaPatchRequest);
 
         /// <summary>
-        /// Sends a PATCH request that expected data in return.
+        /// Sends a PATCH request that requires data in return.
         /// </summary>
         /// <param name="siestaPatchRequest">The request to send.</param>
         /// <param name="currentCorrelationId">If you are using a correlation ID and you are already part of a call you can pass this here.</param>

--- a/Siesta.Client/Siesta.Client.csproj
+++ b/Siesta.Client/Siesta.Client.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <Version>0.3.4</Version>
-        <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
         <LangVersion>9</LangVersion>
         <Nullable>enable</Nullable>
         <CodeAnalysisRuleSet>..\Siesta.ruleset</CodeAnalysisRuleSet>

--- a/Siesta.Configuration.Tests/Siesta.Configuration.Tests.csproj
+++ b/Siesta.Configuration.Tests/Siesta.Configuration.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <IsPackable>false</IsPackable>
         <Nullable>enable</Nullable>
         <CodeAnalysisRuleSet>..\Siesta.Tests.ruleset</CodeAnalysisRuleSet>

--- a/Siesta.Configuration/RequestConfiguration/EnumerableFilterInformation.cs
+++ b/Siesta.Configuration/RequestConfiguration/EnumerableFilterInformation.cs
@@ -35,7 +35,7 @@ namespace Siesta.Configuration.RequestConfiguration
                 var value = property.GetValue(this);
                 if (value?.ToString() is not null)
                 {
-                    dictionary.Add(property.Name, Uri.EscapeUriString(value.ToString() !));
+                    dictionary.Add(property.Name, Uri.EscapeDataString(value.ToString() !));
                 }
             }
 

--- a/Siesta.Configuration/RequestConfiguration/SiestaRequest.cs
+++ b/Siesta.Configuration/RequestConfiguration/SiestaRequest.cs
@@ -4,7 +4,7 @@ namespace Siesta.Configuration.RequestConfiguration
     using Siesta.Configuration.Exceptions;
 
     /// <summary>
-    /// Base class for any request that expects no data to be returned.
+    /// Base class for any request that requires no data to be returned.
     /// </summary>
     public abstract class SiestaRequest
     {

--- a/Siesta.Configuration/Siesta.Configuration.csproj
+++ b/Siesta.Configuration/Siesta.Configuration.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <Version>0.3.4</Version>
-        <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
         <LangVersion>9</LangVersion>
         <Nullable>enable</Nullable>
         <CodeAnalysisRuleSet>..\Siesta.ruleset</CodeAnalysisRuleSet>


### PR DESCRIPTION
# Description

Allows a request to require no content, even if content is returned. This is a more true use case, as you may not always be interested in, or know the content returned.
Addresses LUP-XXX (issue)

## Type of change

Please delete options that are not relevant.
- [x] Bugfix
- [ ] New feature
- [ ] Documentation
- [ ] Testing
- [ ] Other (please add options as needed for commit types)

# How Has This Been Tested?

Unit tested

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

# Comments

Please start all comments with the correct emoji to denote the severity of the comment:

:sweat_drops: - No big deal, does not need fixing, just a comment
:hammer: - please fix before merging, once fixed can then be merged
:fire: - needs completely reworking and will need re-reviewing
